### PR TITLE
Update .gitignore to ignore .python-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ gh-pages/
 
 searx/version_frozen.py
 .dir-locals.el
+
+.python-version


### PR DESCRIPTION
## What does this PR do?
Ignore `.python-version` used by `pyenv`.


## Why is this change important?
I use `pyenv` to utilize Python 3.8 during development to target the minimal version. However, if the file gets accidentally checked in, this could mean that others also using `pyenv` would use Python 3.8 when running the project. This was accidentally encountered [#3316](https://github.com/searxng/searxng/pull/3316/files#diff-652bad7c1002badcf13f8de3a5096c2724ce54ae36cd68a21ad280547dff8e87).

## How to test this PR locally?
n/a

## Author's checklist
n/a

## Related issues
n/a
